### PR TITLE
assembly and parameter updates

### DIFF
--- a/assembly.scad
+++ b/assembly.scad
@@ -34,16 +34,39 @@ create_empty = true;
 // height of the empty module
 empty_height = 30; // [10:1:60]
 
+/* [OLED Module] */
+create_oled = true;
+
+// height of the module
+oled_module_height = 40; // [10:1:100]
+
+// width of the display
+oled_width = 26; //[10:1:100]
+// height of the display
+oled_height = 13; //[10:1:100]
+// width of the pcb
+oled_pcb_width = 27; //[10:1:100]
+// height of the pcb
+oled_pcb_height = 27; //[10:1:100]
+//position of the display (lower edge)
+oled_y_position = 6.5;
+
 /* [Hidden] */
 
 $fn = 256;
 base_radius = base_diameter / 2;
 
 use <module_empty.scad>
+use <module_oled.scad>
+
+oled_module_start = create_empty?base_height+empty_height:base_height;
 
 union() {
 	base(base_radius, base_height, wall_thickness, board_length, board_width, port_width, port_height);
 	if (create_empty)
 		translate([0,0,base_height])
 			empty(base_radius, empty_height, wall_thickness);
+	if (create_oled)
+		translate([0,0,oled_module_start])
+			oled(base_radius, oled_module_height, wall_thickness, oled_width, oled_height, oled_pcb_width, oled_pcb_height, oled_y_position);
 }

--- a/assembly.scad
+++ b/assembly.scad
@@ -1,15 +1,6 @@
 // Unfortunately, customizable parameters have to be in the main file,
 // although they are used in the libraries
 
-use <base.scad>
-
-/* [PCB Dimensions] */
-
-// width of a PCB
-board_width = 26; //[18:Arduino_Nano, 23:Feather_HUZZAH, 26:NodeMCUv2, 30:Raspberry_Pi_ZeroW, 31:NodeMCUv3, 53.3:Arduino_Mega, 53.4:Arduino_Uno]
-// length of a PCB
-board_length = 48; //[45:Arduino_Nano, 48:NodeMCUv2, 51:NodeMCUv3, 51:Feather_HUZZAH, 65:Raspberry_Pi_ZeroW, 68.6:Arduino_Uno, 101.52:Arduino_Mega]
-
 /* [Case Dimensions] */
 
 // diameter of the base
@@ -18,6 +9,13 @@ base_diameter = 62.8; //[62.8:Small, 80:Medium, 100:Large, 130:XLarge]
 wall_thickness = 3; //[2:1:5]
 // height of the base
 base_height = 30; //[20:5:100]
+
+/* [PCB Dimensions] */
+
+// width of a PCB
+board_width = 26; //[18:Arduino_Nano, 23:Feather_HUZZAH, 26:NodeMCUv2, 30:Raspberry_Pi_ZeroW, 31:NodeMCUv3, 53.3:Arduino_Mega, 53.4:Arduino_Uno]
+// length of a PCB
+board_length = 48; //[45:Arduino_Nano, 48:NodeMCUv2, 51:NodeMCUv3, 51:Feather_HUZZAH, 65:Raspberry_Pi_ZeroW, 68.6:Arduino_Uno, 101.52:Arduino_Mega]
 
 /* [Access Port Dimensions] */
 
@@ -51,15 +49,32 @@ oled_pcb_height = 27; //[10:1:100]
 //position of the display (lower edge)
 oled_y_position = 6.5;
 
+/* [Sensor enclosure] */ 
+create_enclosure = true;
+
+// thickness of outer wall
+enclosure_wall_thickness = 2; //[2:1:5]
+// height of the enclosure
+enclosure_height = 15; //[10:3:100]
+// length of the enclosure
+enclosure_length = 40; //[10:5:100]
+// width of the enclosure
+enclosure_width = 25; //[10:5:100]
+// radius of port access
+enclosure_port_radius = 4; //[2:1:20]
+
 /* [Hidden] */
 
 $fn = 256;
 base_radius = base_diameter / 2;
 
+use <base.scad>
 use <module_empty.scad>
 use <module_oled.scad>
+use <module_enclosure.scad>
 
 oled_module_start = create_empty?base_height+empty_height:base_height;
+enclosure_module_start = create_oled?oled_module_start+oled_module_height:oled_module_start;
 
 union() {
 	base(base_radius, base_height, wall_thickness, board_length, board_width, port_width, port_height);
@@ -69,4 +84,8 @@ union() {
 	if (create_oled)
 		translate([0,0,oled_module_start])
 			oled(base_radius, oled_module_height, wall_thickness, oled_width, oled_height, oled_pcb_width, oled_pcb_height, oled_y_position);
+    if (create_enclosure)
+		translate([0,0,enclosure_module_start])
+    		sensor_enclosure(enclosure_length, enclosure_width, base_radius, enclosure_height, enclosure_wall_thickness, enclosure_port_radius);
+
 }

--- a/assembly.scad
+++ b/assembly.scad
@@ -10,15 +10,24 @@ wall_thickness = 3; //[2:1:5]
 
 /* [Base Module] */
 
-// width of a PCB
-board_width = 26; //[18:Arduino_Nano, 23:Feather_HUZZAH, 26:NodeMCUv2, 30:Raspberry_Pi_ZeroW, 31:NodeMCUv3, 53.3:Arduino_Mega, 53.4:Arduino_Uno]
-// length of a PCB
-board_length = 48; //[45:Arduino_Nano, 48:NodeMCUv2, 51:NodeMCUv3, 51:Feather_HUZZAH, 65:Raspberry_Pi_ZeroW, 68.6:Arduino_Uno, 101.52:Arduino_Mega]
+//type of uC
+board = 0; //[0: Custom, 1:Arduino_Nano, 2:Arduino_Mega, 3:Arduino_Uno, 4:Feather_HUZZAH, 5:NodeMCUv2, 6:NodeMCUv3, 7:Raspberry_Pi_ZeroW]
+
+// width of a PCB (only for Custom)
+board_width = 26; //[10:0.1:150]
+// length of a PCB  (only for Custom)
+board_length = 48; //[10:0.1:150]
+
+/* [Access Port Dimensions (only for Custom)] */
 
 // width of the port hole for e.g. USB access
 port_width = 10; //[5:1:50]
 // height of the port hole for e.g. USB access
 port_height = 6; //[4:1:30]
+// position from left edge of board to middle of port
+port_ypos = 5; //[0:1:150]
+// position from bottom of pcb (negative is below)
+port_zpos = 0; //[-25:1:30]
 
 /* [Empty Module] */
 
@@ -70,7 +79,7 @@ oled_module_start = create_empty?base_height()+empty_height:base_height();
 enclosure_module_start = create_oled?oled_module_start+oled_module_height():oled_module_start;
 
 union() {
-	base(base_radius, wall_thickness, board_length, board_width, port_width, port_height);
+	base(base_radius, wall_thickness, board, port_width, port_height, port_ypos, port_zpos);
 	if (create_empty)
 		translate([0,0,empty_height])
 			empty(base_radius, empty_height, wall_thickness);

--- a/assembly.scad
+++ b/assembly.scad
@@ -7,17 +7,13 @@
 base_diameter = 62.8; //[62.8:Small, 80:Medium, 100:Large, 130:XLarge]
 // thickness of outer wall
 wall_thickness = 3; //[2:1:5]
-// height of the base
-base_height = 30; //[20:5:100]
 
-/* [PCB Dimensions] */
+/* [Base Module] */
 
 // width of a PCB
 board_width = 26; //[18:Arduino_Nano, 23:Feather_HUZZAH, 26:NodeMCUv2, 30:Raspberry_Pi_ZeroW, 31:NodeMCUv3, 53.3:Arduino_Mega, 53.4:Arduino_Uno]
 // length of a PCB
 board_length = 48; //[45:Arduino_Nano, 48:NodeMCUv2, 51:NodeMCUv3, 51:Feather_HUZZAH, 65:Raspberry_Pi_ZeroW, 68.6:Arduino_Uno, 101.52:Arduino_Mega]
-
-/* [Access Port Dimensions] */
 
 // width of the port hole for e.g. USB access
 port_width = 10; //[5:1:50]
@@ -34,9 +30,6 @@ empty_height = 30; // [10:1:60]
 
 /* [OLED Module] */
 create_oled = true;
-
-// height of the module
-oled_module_height = 40; // [10:1:100]
 
 // width of the display
 oled_width = 26; //[10:1:100]
@@ -73,17 +66,17 @@ use <module_empty.scad>
 use <module_oled.scad>
 use <module_enclosure.scad>
 
-oled_module_start = create_empty?base_height+empty_height:base_height;
-enclosure_module_start = create_oled?oled_module_start+oled_module_height:oled_module_start;
+oled_module_start = create_empty?base_height()+empty_height:base_height();
+enclosure_module_start = create_oled?oled_module_start+oled_module_height():oled_module_start;
 
 union() {
-	base(base_radius, base_height, wall_thickness, board_length, board_width, port_width, port_height);
+	base(base_radius, wall_thickness, board_length, board_width, port_width, port_height);
 	if (create_empty)
-		translate([0,0,base_height])
+		translate([0,0,empty_height])
 			empty(base_radius, empty_height, wall_thickness);
 	if (create_oled)
 		translate([0,0,oled_module_start])
-			oled(base_radius, oled_module_height, wall_thickness, oled_width, oled_height, oled_pcb_width, oled_pcb_height, oled_y_position);
+			oled(base_radius, wall_thickness, oled_width, oled_height, oled_pcb_width, oled_pcb_height, oled_y_position);
     if (create_enclosure)
 		translate([0,0,enclosure_module_start])
     		sensor_enclosure(enclosure_length, enclosure_width, base_radius, enclosure_height, enclosure_wall_thickness, enclosure_port_radius);

--- a/base.scad
+++ b/base.scad
@@ -13,8 +13,6 @@ board_length = 48; //[45:Arduino_Nano, 48:NodeMCUv2, 51:NodeMCUv3, 51:Feather_HU
 base_diameter = 62.8; //[62.8:Small, 80:Medium, 100:Large, 130:XLarge]
 // thickness of outer wall
 wall_thickness = 3; //[2:1:5]
-// height of the base
-base_height = 30; //[20:5:100]
 
 /* [Access Port Dimensions] */
 
@@ -30,6 +28,7 @@ base_radius = base_diameter / 2;
 
 use <common.scad>
 
+function base_height() = 30; //fixed, but needs to be fine-tuned to pcb+pins+connectors+bending radius of cables
 standoff_height = 12;
 standoff_width = wall_thickness;
 ground_clearance = 5;
@@ -86,8 +85,8 @@ module port_access(length, height) {
 			// add new inner wall
 			intersection() { // cut everything not inside the original enclosure shape
 				// same as base
-				translate([0, 0, base_height/2])
-					cylinder(h = base_height, d = base_diameter, center = true);
+				translate([0, 0, base_height()/2])
+					cylinder(h = base_height(), d = base_diameter, center = true);
 				// recess
 				translate([board_length/2, -(2*base_radius+5)/2, 0]) {
 					cube([base_radius+5, 2*base_radius+5, ground_clearance + wall_thickness + 1 + height + 1]);
@@ -113,12 +112,12 @@ module port_access(length, height) {
 }
 
 // main housing of the uC
-module base(base_radius, base_height, wall_thickness, board_length, board_width, port_width, port_height) {
+module base(base_radius, wall_thickness, board_length, board_width, port_width, port_height) {
 	port_access(port_width, port_height) {
 		union() {
 			difference() {
-				shell(base_radius*2, base_height, wall_thickness, true);
-				venting_holes(0, base_radius, base_height, 10, 5, true);
+				shell(base_radius*2, base_height(), wall_thickness, true);
+				venting_holes(0, base_radius, base_height(), 10, 5, true);
 			};
 
 			// board dummy
@@ -126,10 +125,10 @@ module base(base_radius, base_height, wall_thickness, board_length, board_width,
 				cube([board_length, board_width, 2]);
 
 			standoffs(board_length, board_width, ground_clearance);
-			connectors_female(90, base_radius, base_height, wall_thickness);
-			connectors_female(270, base_radius, base_height, wall_thickness);
+			connectors_female(90, base_radius, base_height(), wall_thickness);
+			connectors_female(270, base_radius, base_height(), wall_thickness);
 		}
 	}
 }
 
-base(base_radius, base_height, wall_thickness, board_length, board_width, port_width, port_height);
+base(base_radius, wall_thickness, board_length, board_width, port_width, port_height);

--- a/base.scad
+++ b/base.scad
@@ -1,12 +1,5 @@
 // Creates the enclosure base with space for a PCB and access to its ports.
 
-/* [PCB Dimensions] */
-
-// width of a PCB
-board_width = 26; //[18:Arduino_Nano, 23:Feather_HUZZAH, 26:NodeMCUv2, 30:Raspberry_Pi_ZeroW, 31:NodeMCUv3, 53.3:Arduino_Mega, 53.4:Arduino_Uno]
-// length of a PCB
-board_length = 48; //[45:Arduino_Nano, 48:NodeMCUv2, 51:NodeMCUv3, 51:Feather_HUZZAH, 65:Raspberry_Pi_ZeroW, 68.6:Arduino_Uno, 101.52:Arduino_Mega]
-
 /* [Case Dimensions] */
 
 // diameter of the base
@@ -14,16 +7,32 @@ base_diameter = 62.8; //[62.8:Small, 80:Medium, 100:Large, 130:XLarge]
 // thickness of outer wall
 wall_thickness = 3; //[2:1:5]
 
-/* [Access Port Dimensions] */
+
+/* [PCB Dimensions] */
+
+//type of uC
+board = 0; //[0: Custom, 1:Arduino_Nano, 2:Arduino_Mega, 3:Arduino_Uno, 4:Feather_HUZZAH, 5:NodeMCUv2, 6:NodeMCUv3, 7:Raspberry_Pi_ZeroW]
+
+// width of a PCB (only for Custom)
+board_width = 26; //[10:0.1:150]
+// length of a PCB  (only for Custom)
+board_length = 48; //[10:0.1:150]
+
+/* [Access Port Dimensions (only for Custom)] */
 
 // width of the port hole for e.g. USB access
 port_width = 10; //[5:1:50]
 // height of the port hole for e.g. USB access
 port_height = 6; //[4:1:30]
+// position from left edge of board to middle of port
+port_ypos = 5; //[0:1:150]
+// position from bottom of pcb (negative is below)
+port_zpos = 0; //[-25:1:30]
 
 /* [Hidden] */
 
 $fn = 256;
+
 base_radius = base_diameter / 2;
 
 use <common.scad>
@@ -32,6 +41,7 @@ function base_height() = 30; //fixed, but needs to be fine-tuned to pcb+pins+con
 standoff_height = 12;
 standoff_width = wall_thickness;
 ground_clearance = 5;
+
 
 // a single standoff with a small rest to keep a board from the ground
 // height: overall height; width: wall-thickness and nook,
@@ -78,7 +88,7 @@ module standoffs(length, width, clearance) {
 
 // cut a recess with port access into base
 // parameters are length/width of port access hole
-module port_access(length, height) {
+module port_access(base_radius, length, height, port_ypos, port_zpos, board_length, board_width) {
 	difference() {
 		union() {
 			children(); // <- the rest of the model
@@ -86,7 +96,7 @@ module port_access(length, height) {
 			intersection() { // cut everything not inside the original enclosure shape
 				// same as base
 				translate([0, 0, base_height()/2])
-					cylinder(h = base_height(), d = base_diameter, center = true);
+					cylinder(h = base_height(), d = base_radius*2, center = true);
 				// recess
 				translate([board_length/2, -(2*base_radius+5)/2, 0]) {
 					cube([base_radius+5, 2*base_radius+5, ground_clearance + wall_thickness + 1 + height + 1]);
@@ -106,14 +116,14 @@ module port_access(length, height) {
 			rotate([0,60,0])
 				cube([base_radius - board_length/2 + 5, 2*base_radius+5, base_radius]);
 		// cut port hole
-		translate([board_length/2 - 1, - length/2, -height/2 + wall_thickness + ground_clearance - 1])
+		translate([board_length/2 - 1, -board_width/2 - length/2 + port_ypos, wall_thickness + ground_clearance +port_zpos])
 			cube([50, length, height]);
 	}
 }
 
 // main housing of the uC
-module base(base_radius, wall_thickness, board_length, board_width, port_width, port_height) {
-	port_access(port_width, port_height) {
+module _base(base_radius, wall_thickness, board_length, board_width, port_width, port_height, port_ypos, port_zpos) {
+	port_access(base_radius, port_width, port_height, port_ypos, port_zpos, board_length, board_width) {
 		union() {
 			difference() {
 				shell(base_radius*2, base_height(), wall_thickness, true);
@@ -131,4 +141,32 @@ module base(base_radius, wall_thickness, board_length, board_width, port_width, 
 	}
 }
 
-base(base_radius, wall_thickness, board_length, board_width, port_width, port_height);
+module base(base_radius, wall_thickness, board, port_width, port_height, port_ypos, port_zpos) {
+	// board dimensions database (unique variables needed due to languare restrictions)
+	board_size1 = board==0?[board_width, board_length]:[1,1]; //custom
+	board_size2 = board==1?[ 45   , 18   ]:board_size1; // Arduino_Nano
+	board_size3 = board==2?[ 68.6 , 53.3 ]:board_size2; // Arduino_Uno
+	board_size4 = board==3?[101.52, 53.4 ]:board_size3; // Arduino_Mega
+	board_size5 = board==4?[ 51   , 23   ]:board_size4; // Feather_HUZZAH
+	board_size6 = board==5?[ 48   , 26   ]:board_size5; // NodeMCUv2
+	board_size7 = board==6?[ 51   , 31   ]:board_size6; // NodeMCUv3
+	board_size8 = board==7?[ 65   , 30   ]:board_size7; // Raspberry_Pi_ZeroW
+
+	board_size = board_size8; // use last variable from table above here
+
+	//port dimensions [width, height, ypos, zpos]
+	port1 = board==0?[port_width, port_height, port_ypos, port_zpos]:[10,16,5,0]; //custom
+	port2 = board==1?[ 1,1,1,1 ]:port1; // Arduino_Nano
+	port3 = board==2?[ 1,1,1,1 ]:port2; // Arduino_Uno
+	port4 = board==3?[ 1,1,1,1 ]:port3; // Arduino_Mega
+	port5 = board==4?[ 1,1,1,1 ]:port4; // Feather_HUZZAH
+	port6 = board==5?[ 10, 7, 13  , -4.5 ]:port5; // NodeMCUv2
+	port7 = board==6?[ 10, 7, 15.5, -4.5 ]:port6; // NodeMCUv3
+	port8 = board==7?[ 1,1,1,1   ]:port7; // Raspberry_Pi_ZeroW
+
+	port = port8; // use last variable from table above here
+
+	_base(base_radius, wall_thickness, board_size[0], board_size[1], port[0], port[1], port[2], port[3]);
+}
+
+base(base_radius, wall_thickness, board, port_width, port_height, port_ypos, port_zpos);

--- a/common.scad
+++ b/common.scad
@@ -67,32 +67,6 @@ module connectors_male(angle, base_radius, wall_thickness) {
 		}
 }
 
-// adds a sensor enclosure to the module
-// parameters are length/width of enclosure
-module enclosure(angle, length, width, base_radius, base_height, wall_thickness, port_radius) {
-	difference() {
-		difference() {
-			translate([base_radius-length-wall_thickness,-width/2,0])
-				difference() {
-					cube([length, width, base_height], false);
-					translate([wall_thickness,wall_thickness,wall_thickness])
-						cube([length, width-wall_thickness*2, base_height-wall_thickness+1], false);
-				}
-
-			// wiring hole
-			translate([base_radius-length-wall_thickness-1, 0, base_height/2+wall_thickness/2])
-				rotate([0,90,0])
-					cylinder(wall_thickness+2, r = port_radius);
-		}
-
-		// make sure we don't exceed the outer shell
-		difference() {
-			cylinder(h = base_height * 4, d = base_radius * 2.5, center = true);
-			cylinder(h = base_height * 4 + 2, d = base_radius * 2, center = true);
-		}
-	}
-}
-
 // cut array of venting holes
 module venting_holes(angle, base_radius, base_height, xnum, ynum, twosided) {
 	width = 1;

--- a/module_enclosure.scad
+++ b/module_enclosure.scad
@@ -38,11 +38,41 @@ base_radius = base_diameter / 2;
 use <common.scad>
 use <module_empty.scad>
 
-union() {
-    difference() {
-        empty(base_radius, module_height, wall_thickness);
-        venting_holes(90, base_radius, module_height, enclosure_vents_x, enclosure_vents_y, enclosure_vents_twosided);
-    }
+// adds a sensor enclosure to the module
+// parameters are length/width of enclosure
+module enclosure(angle, length, width, base_radius, base_height, wall_thickness, port_radius) {
+	difference() {
+		difference() {
+			translate([base_radius-length-wall_thickness,-width/2,0])
+				difference() {
+					cube([length, width, base_height], false);
+					translate([wall_thickness,wall_thickness,wall_thickness])
+						cube([length, width-wall_thickness*2, base_height-wall_thickness+1], false);
+				}
 
-    enclosure(90, enclosure_length, enclosure_width, base_radius, enclosure_height, enclosure_wall_thickness, enclosure_port_radius);
+			// wiring hole
+			translate([base_radius-length-wall_thickness-1, 0, base_height/2+wall_thickness/2])
+				rotate([0,90,0])
+					cylinder(wall_thickness+2, r = port_radius);
+		}
+
+		// make sure we don't exceed the outer shell
+		difference() {
+			cylinder(h = base_height * 4, d = base_radius * 2.5, center = true);
+			cylinder(h = base_height * 4 + 2, d = base_radius * 2, center = true);
+		}
+	}
 }
+
+module sensor_enclosure(enclosure_length, enclosure_width, base_radius, enclosure_height, enclosure_wall_thickness, enclosure_port_radius){
+	union() {
+	    difference() {
+	        empty(base_radius, module_height, wall_thickness);
+	        venting_holes(90, base_radius, module_height, enclosure_vents_x, enclosure_vents_y, enclosure_vents_twosided);
+	    }
+
+	    enclosure(90, enclosure_length, enclosure_width, base_radius, enclosure_height, enclosure_wall_thickness, enclosure_port_radius);
+	}
+}
+
+sensor_enclosure(enclosure_length, enclosure_width, base_radius, enclosure_height, enclosure_wall_thickness, enclosure_port_radius);

--- a/module_oled.scad
+++ b/module_oled.scad
@@ -5,8 +5,6 @@
 base_diameter = 62.8; //[62.8:Small, 80:Medium, 100:Large, 130:XLarge]
 // thickness of outer wall
 wall_thickness = 3; //[2:1:5]
-// height of the module
-module_height = 20; //[10:5:100]
 
 /* [OLED Dimensions] */
 
@@ -49,18 +47,19 @@ module cutInner(radius, module_height)
 	}
 }
 
-module oled(base_radius, module_height, wall_thickness, oled_width, oled_height, oled_pcb_width, oled_pcb_height, oled_y_position) {
+function oled_module_height() = oled_pcb_height + 2*wall_thickness + 2*frame;
+
+module oled(base_radius, wall_thickness, oled_width, oled_height, oled_pcb_width, oled_pcb_height, oled_y_position) {
 	// lock minimum module height
-	_module_height = (module_height <= oled_pcb_height + 2*wall_thickness + 2*frame)?oled_pcb_height + 2*wall_thickness+2*frame: module_height;
 
 	union() {
 		difference(){
 			union(){
 				//base
-	    		empty(base_radius, _module_height, wall_thickness);
+	    		empty(base_radius, oled_module_height(), wall_thickness);
 	    		//frame
-	    		cutInner(base_radius - 2.5*wall_thickness, _module_height){
-		    		cutOuter(base_radius - wall_thickness, _module_height){
+	    		cutInner(base_radius - 2.5*wall_thickness, oled_module_height()){
+		    		cutOuter(base_radius - wall_thickness, oled_module_height()){
 			    		translate([5, -(oled_pcb_width/2 + wall_thickness/2),  frame])
 			    			cube([base_radius, oled_pcb_width + wall_thickness, oled_pcb_height + 2*wall_thickness]);
 			    	};
@@ -96,4 +95,4 @@ module oled(base_radius, module_height, wall_thickness, oled_width, oled_height,
 	}
 }
 
-oled(base_radius, module_height, wall_thickness, oled_width, oled_height, oled_pcb_width, oled_pcb_height, oled_y_position);
+oled(base_radius, wall_thickness, oled_width, oled_height, oled_pcb_width, oled_pcb_height, oled_y_position);

--- a/module_oled.scad
+++ b/module_oled.scad
@@ -29,37 +29,38 @@ base_radius = base_diameter / 2;
 
 frame = 1; // plastic frame around pcb
 
-// lock minimum module height
-_module_height = (module_height <= oled_pcb_height + 2*wall_thickness + 2*frame)?oled_pcb_height + 2*wall_thickness+2*frame: module_height;
 
 use <common.scad>
 use <module_empty.scad>
 
-module cutOuter(radius)
+module cutOuter(radius, module_height)
 {
 	intersection(){
 		children();
-		cylinder(r=radius, h=_module_height);
+		cylinder(r=radius, h=module_height);
 	}
 }
 
-module cutInner(radius)
+module cutInner(radius, module_height)
 {
 	difference(){
 		children();
-		cylinder(r=radius, h=_module_height);
+		cylinder(r=radius, h=module_height);
 	}
 }
 
-module oled(base_radius, module_height, wall_thickness) {
+module oled(base_radius, module_height, wall_thickness, oled_width, oled_height, oled_pcb_width, oled_pcb_height, oled_y_position) {
+	// lock minimum module height
+	_module_height = (module_height <= oled_pcb_height + 2*wall_thickness + 2*frame)?oled_pcb_height + 2*wall_thickness+2*frame: module_height;
+
 	union() {
 		difference(){
 			union(){
 				//base
 	    		empty(base_radius, _module_height, wall_thickness);
 	    		//frame
-	    		cutInner(base_radius - 2.5*wall_thickness){
-		    		cutOuter(base_radius - wall_thickness){
+	    		cutInner(base_radius - 2.5*wall_thickness, _module_height){
+		    		cutOuter(base_radius - wall_thickness, _module_height){
 			    		translate([5, -(oled_pcb_width/2 + wall_thickness/2),  frame])
 			    			cube([base_radius, oled_pcb_width + wall_thickness, oled_pcb_height + 2*wall_thickness]);
 			    	};
@@ -95,4 +96,4 @@ module oled(base_radius, module_height, wall_thickness) {
 	}
 }
 
-oled(base_radius, _module_height, wall_thickness);
+oled(base_radius, module_height, wall_thickness, oled_width, oled_height, oled_pcb_width, oled_pcb_height, oled_y_position);


### PR DESCRIPTION
I've reduced the number of manual, analog parameters in favor of a board selection that gets the values from an internal 'database' (okok, it's just a table). This should make it more convenient to get the right-size  enclosure to print.

Still needs a lot of values though to make it usable for more boards. Could somebody maybe create a github wiki page to collect some measurements for boards so people without coding/github experience can contribute?

I've decided that the access port position and dimension is also something that should be fixed with the board selection. We need values for those too.

(Custom dimensions are still an option though.)

The base diameter could also be directly derived from the selected board and I think i could make it work in both the base_module as well as the assembly. But people will print the other modules not from the assembly, but from their specific files and there is no way of communicating a selected parameter in one stand-alone module file to another one. These are essentially two distinct compiler runs with no shared communication.
So people still need to select the diameter on those other modules, so I think it's better to keep that S/M/L/XL selection on all of them for consistency instead of doing it automatically for the base and then letting the user get the value from the logs (are they accessible on thingieverse?) and only re-enter them for the other modules.
Discussions welcome ....